### PR TITLE
Update the Lokalise URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lokalise
 
-Download your translation files from the [Lokalise](https://lokali.se)
+Download your translation files from the [Lokalise](https://lokalise.co)
 translation service. Use as a command-line tool (e.g. from a Bash script) or as
 a Ruby class.
 
@@ -21,12 +21,12 @@ Or install it yourself as:
 > bundle exec lokalise
 
 # Typical usage - mandatory project ID and auth token (which can also be in
-  environment variable; get your token from https://lokali.se/account)
+  environment variable; get your token from https://lokalise.co/account)
 > bundle exec lokalize --token aab14314 1234567e0.0129
 
 Options:
 -t, --token              API token (default: LOKALISE_API_TOKEN env variable; from:
-                         https://lokali.se/en/account)
+                         https://lokalise.co/en/account)
 -f, --format             output format (default: yml)
 -o, --output-folder      output folder (default: current folder; will be created if
                          doesnt exist)

--- a/exe/lokalise
+++ b/exe/lokalise
@@ -9,7 +9,7 @@ e.g.: lokalize.rb --token aab14314 -output-folder=translations 1234567e0.0129
 
 Download string files from Lokalize projects, for more information
 DESC
-  o.string '-t', '--token', 'API token (default: LOKALISE_API_TOKEN env variable; from: https://lokali.se/en/account)'
+  o.string '-t', '--token', 'API token (default: LOKALISE_API_TOKEN env variable; from: https://lokalise.co/en/account)'
   o.string '-f', '--format', 'output format (default: yml)', default: :yml
   o.string '-o', '--output-folder', 'output folder (default: current folder; will be created if doesn''t exist)'
   o.string '-st', '--structure', 'output structure (default: \'%PROJECT_NAME%.%LANG_ISO%.%FORMAT%\')'

--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -26,7 +26,7 @@ module Lokalise
     # PUBLIC INTERFACE
     ######################################################################
 
-    property :lokalise_api_token # Get this from https://lokali.se/en/account
+    property :lokalise_api_token # Get this from https://lokalise.co/en/account
     property :output_folder
     property :output_format, default: :yml
     property :structure, default: '%PROJECT_NAME%.%LANG_ISO%.%FORMAT%'
@@ -74,7 +74,7 @@ module Lokalise
       )
 
       fetch_start = Time.now
-      response = Excon.post 'https://lokali.se/api/project/export',
+      response = Excon.post 'https://lokalise.co/api/project/export',
         headers: headers,
         body: body,
         read_timeout: 600
@@ -95,7 +95,7 @@ module Lokalise
     end
 
     def download_zip
-      zip_url_on_server = "https://lokali.se/#{@zip_path_on_server}"
+      zip_url_on_server = "https://lokalise.co/#{@zip_path_on_server}"
       log "Downloading zip file from #{zip_url_on_server}"
       `curl --silent #{zip_url_on_server} > #{ZIP_FILE}`
     end

--- a/lokalise.gemspec
+++ b/lokalise.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Michael Mahemoff', 'Eden Vicary']
   spec.email         = ['michael@mahemoff.com']
 
-  spec.summary       = 'Pull Lokali.se translations'
-  spec.description   = 'Download translation files from the Lokali.se'
+  spec.summary       = 'Pull Lokalise translations'
+  spec.description   = 'Download translation files from the Lokalise'
   spec.homepage      = 'https://github.com/mahemoff/lokalise'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
Lokalise have recently changed their URL from lokali.se to lokalise.co.
This change has broken our translation fetch, so this commit updates the
URL to the new one.
